### PR TITLE
Make DslScriptSpec test work with Windows paths

### DIFF
--- a/src/test/groovy/dsls/DslScriptSpec.groovy
+++ b/src/test/groovy/dsls/DslScriptSpec.groovy
@@ -25,7 +25,7 @@ class DslScriptSpec extends Specification {
     private static def findDslFiles() {
         List<File> files = []
         new File('src/main/groovy/dsls').eachFileRecurse {
-            if (!it.path.contains('/utilities/') && it.name.endsWith('.groovy')) {
+            if (!it.path.contains("${File.separator}utilities${File.separator}") && it.name.endsWith('.groovy')) {
                 files << it
             }
         }


### PR DESCRIPTION
If we want to exclude the code in `/utilities/` from DSL validation in Windows, we need to use the OS-agnostic file separator: `File.separator`